### PR TITLE
Add optional importUrl to Shapefile method signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ to be done in a worker, you'll need [catiline](https://github.com/calvinmetcalf/
 usage:
 
 ```javascript
-new L.Shapefile(arrayBuffer or url[,options]);
+new L.Shapefile(arrayBuffer or url[,options][,importUrl]);
 
-L.shapefile(arrayBuffer or url[,options]);
+L.shapefile(arrayBuffer or url[,options][,importUrl]);
 ```
 
 Options are passed to L.Geojson as is. First argument is either an array buffer of a zipped shapefile,
-the url to a zipped shapefile, or the url to file.shp (this assumes file.dbf exists).
+the url to a zipped shapefile, or the url to file.shp (this assumes file.dbf exists). The importUrl parameter allows you to change where a worker loads in `shp.js` when using [catiline](https://github.com/calvinmetcalf/catiline) and defaults to `shp.js`.
 
 To easily try this out using your own shapefile, see the demo at [leaflet.calvinmetcalf.com](http://leaflet.calvinmetcalf.com/), where you can drag-and-drop your own shapefile and have it displayed on the map.

--- a/leaflet.shpfile.js
+++ b/leaflet.shpfile.js
@@ -1,8 +1,11 @@
 L.Shapefile =L.GeoJSON.extend({
-    initialize: function (file, options) {
+    initialize: function (file, options, importUrl) {
         if(typeof cw !== 'undefined'){
+            if (typeof importUrl === 'undefined') {
+            	importUrl = 'shp.js';
+            }
             this.worker = cw(function(data,cb){
-                importScripts('shp.js');
+                importScripts(importUrl);
 	            shp(data).then(cb);
             });
         }
@@ -33,6 +36,6 @@ L.Shapefile =L.GeoJSON.extend({
     }
 });
 
-L.shapefile= function(a,b){
-    return new L.Shapefile(a,b);
+L.shapefile= function(a,b,c){
+    return new L.Shapefile(a,b,c);
 }

--- a/leaflet.shpfile.js
+++ b/leaflet.shpfile.js
@@ -1,11 +1,8 @@
 L.Shapefile =L.GeoJSON.extend({
     initialize: function (file, options, importUrl) {
         if(typeof cw !== 'undefined'){
-            if (typeof importUrl === 'undefined') {
-            	importUrl = 'shp.js';
-            }
             this.worker = cw(function(data,cb){
-                importScripts(importUrl);
+                importScripts(importUrl || 'shp.js');
 	            shp(data).then(cb);
             });
         }


### PR DESCRIPTION
Our deployment process changes what url is exposed for scripts, so it's necessary for us to be able to change it.
