### PR TITLE
Switch Leaflet js/css to https to fix mixed content warnings

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<title>
 		Preview
 	</title>
-	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.css" />
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css" />
 	<!--[if lte IE 8]>
 			<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.ie.css" />
 		<![endif]-->
@@ -35,7 +35,7 @@
 		</div>
 	</div>
 	<div id="map"></div>
-	<script src="http://cdn.leafletjs.com/leaflet-0.6.4/leaflet.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
 	<script src="catiline.js"></script>
 	<script src="leaflet.shpfile.js"></script>
 	<script>


### PR DESCRIPTION
This swaps the leaflet includes to use cdnjs as the libraries aren't available over https from the main leaflet site.

I can't find a newer version of the leaflet.ie.css, so have left it as is.
