### PR TITLE
Support for non-latin symbols in geometry attributes

### DIFF
--- a/shp.js
+++ b/shp.js
@@ -12003,7 +12003,8 @@ function dbfRowHeader(buffer){
 }
 function rowFuncs(buffer,offset,len,type){
 	var data = (new Uint8Array(buffer,offset,len));
-	var textData = String.fromCharCode.apply(this,data).replace(/\0|\s+$/g,'');
+	var encodedData = String.fromCharCode.apply(this,data).replace(/\0|\s+$/g,'');
+	var textData = decodeURIComponent(escape(encodedData));
 	switch(type){
 		case 'N':
 		case 'F':


### PR DESCRIPTION
Fix parsing non-latin symbols in geometry attributes.
Code is taken from [StackOverflow](https://stackoverflow.com/questions/17191945/conversion-between-utf-8-arraybuffer-and-string).